### PR TITLE
refactor: replace deprecated commands with modern alternatives

### DIFF
--- a/home/dot_aliases
+++ b/home/dot_aliases
@@ -8,12 +8,11 @@ alias mkdir='mkdir -p'
 alias which='type -a'
 alias job='jobs -l'
 
-alias du='du -kh'
 alias df='df -kTh'
 
 alias grep='grep --color=auto'
-alias fgrep='fgrep --color=auto'
-alias egrep='egrep --color=auto'
+alias fgrep='grep -F --color=auto'
+alias egrep='grep -E --color=auto'
 
 alias wget=wget --hsts-file='$XDG_DATA_HOME/wget-hsts'
 

--- a/home/dot_config/nvim/empty_init.lua
+++ b/home/dot_config/nvim/empty_init.lua
@@ -2,7 +2,6 @@ vim.g.loaded_netrw = 1
 vim.g.loaded_netrwPlugin = 1
 
 vim.opt.encoding = 'utf-8'
-vim.scriptencoding = 'utf-8'
 
 vim.opt.number = true
 
@@ -37,7 +36,6 @@ vim.opt.hlsearch = true
 
 -- misc
 vim.opt.wildmenu = true
-vim.opt.ttyfast = true
 vim.opt.gdefault = true
 vim.opt.termguicolors = true
 vim.opt.mouse = ""

--- a/home/dot_config/nvim/lua/plugins/nvim-treesitter.lua
+++ b/home/dot_config/nvim/lua/plugins/nvim-treesitter.lua
@@ -2,7 +2,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
     config = function()
-      require'nvim-treesitter.configs'.setup {
+      require("nvim-treesitter.configs").setup {
         ensure_installed = { "lua", "python", "vim" },
         highlight = { enable = true },
       }

--- a/install.sh
+++ b/install.sh
@@ -16,13 +16,16 @@ PATH="$HOME/.local/bin:$PATH"
 
 if [ -e /etc/debian_version ]; then
     sudo add-apt-repository -y ppa:neovim-ppa/stable
-    sudo apt install -y \
+    sudo apt-get update
+    sudo apt-get install -y \
         git curl wget zip unzip \
         gcc pipx \
         neovim
 
     # Install mise
-    curl -s https://mise.run | sh
+    curl -fsSL https://mise.run -o /tmp/mise-install.sh
+    bash /tmp/mise-install.sh
+    rm /tmp/mise-install.sh
     ~/.local/bin/mise install aws bat chezmoi dust eza fzf jq starship zoxide gh usage
 
     # Install Python tools (uv for managing Python versions, mypy, pytest, ruff)


### PR DESCRIPTION
- Replace fgrep/egrep with grep -F/grep -E (GNU grep 2.5.3+)
- Remove vim.opt.ttyfast (unnecessary in modern terminal emulators)
- Remove vim.scriptencoding in Lua (scripts are always UTF-8)
- Replace require'module' with require("module") for consistency
- Replace curl | sh with safer two-step download+execute pattern
- Use apt-get instead of apt for script consistency
- Remove duplicate du alias definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>